### PR TITLE
Add security-events: write permission to MSDO sample workflows for De…

### DIFF
--- a/.github/workflows/defender-for-devop2s.yml
+++ b/.github/workflows/defender-for-devop2s.yml
@@ -31,6 +31,9 @@ jobs:
     # currently only windows latest is supported
     runs-on: windows-latest
 
+    permissions:
+      security-events: write
+
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-dotnet@v3

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -1,34 +1,37 @@
 name: MSDO windows-latest
 on:
-      push:
-        branches: [ main ]
-      pull_request:
-        branches: [ main ]
-      workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
-      sample:
+  sample:
 
-        # MSDO runs on windows-latest and ubuntu-latest.
-        # macos-latest supporting coming soon
-        runs-on: windows-latest
+    # MSDO runs on windows-latest and ubuntu-latest.
+    # macos-latest supporting coming soon
+    runs-on: windows-latest
 
-        steps:
-        - uses: actions/checkout@v3
+    permissions:
+      security-events: write
 
-        - uses: actions/setup-dotnet@v3
-          with:
-            dotnet-version: |
-              5.0.x
-              6.0.x
+    steps:
+    - uses: actions/checkout@v3
 
-        # Run analyzers
-        - name: Run Microsoft Security DevOps Analysis
-          uses: microsoft/security-devops-action@preview
-          id: msdo
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          5.0.x
+          6.0.x
 
-        # Upload alerts to the Security tab
-        - name: Upload alerts to Security tab
-          uses: github/upload-sarif@v3
-          with:
-            sarif_file: ${{ steps.msdo.outputs.sarifFile }}
+    # Run analyzers
+    - name: Run Microsoft Security DevOps Analysis
+      uses: microsoft/security-devops-action@preview
+      id: msdo
+
+    # Upload alerts to the Security tab
+    - name: Upload alerts to Security tab
+      uses: github/upload-sarif@v3
+      with:
+        sarif_file: ${{ steps.msdo.outputs.sarifFile }}


### PR DESCRIPTION
According to the documentation [here](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github), the security-events:write permission may be needed in order for the codeql upload-sarif action to be able to upload results to the Security tab.

Please accept this change and see if it resolves the build issue.